### PR TITLE
Add currency query param to all endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ Build with Node, Koa 2, `uws` and Redis.
 
 ## API Endpoints
 
-### Prices 
+### Prices
 
 `GET https://api.lionshare.capital/api/prices`
 
 #### Params
 
 - `period: hour | day | week | month | year`
+- `currency: EUR | GBP | AUD | etc..
 
 Returns historic prices for supported digital currencies
 
@@ -37,6 +38,10 @@ Returns historic prices for supported digital currencies
 
 `GET https://api.lionshare.capital/api/markets`
 
+#### Params
+
+- `currency: EUR | GBP | AUD | etc..
+
 Returns market capitalization data
 
 > Example response:
@@ -44,7 +49,7 @@ Returns market capitalization data
 ```
 {
   "data": {
-    "BTC": 14718750986, 
+    "BTC": 14718750986,
     "ETH": 943628626,
     "LTC": 188560718,
     ...

--- a/api/markets.js
+++ b/api/markets.js
@@ -2,6 +2,7 @@ import Router     from 'koa-router';
 import fetch      from 'isomorphic-fetch';
 
 import Exchange from '../exchange/Exchange';
+import { getCurrencyRate } from '../exchange/Currencies';
 import redis from '../db/redis';
 
 const router = new Router();
@@ -17,9 +18,12 @@ router.get('/', async (ctx) => {
       await redis.setAsync('api-markets', JSON.stringify(markets));
     }
 
+    const currency = ctx.query.currency;
+    const currencyRate = await getCurrencyRate(currency);
+
     const marketCaps = {};
     for (let symbol in markets) {
-      marketCaps[symbol] = markets[symbol]['marketCap']
+      marketCaps[symbol] = (markets[symbol]['marketCap'] * currencyRate)
     }
     ctx.body = { data: marketCaps };
   } catch(e) {

--- a/api/prices.js
+++ b/api/prices.js
@@ -3,6 +3,7 @@ import httpErrors from 'http-errors';
 import fetch from 'isomorphic-fetch';
 
 import Exchange from '../exchange/Exchange';
+import { getCurrencyRate } from '../exchange/Currencies';
 import redis from '../db/redis';
 
 const router = new Router();
@@ -18,6 +19,12 @@ router.get('/', async ctx => {
     if (!prices) {
       prices = await exchange.getPrices(period);
       await redis.setAsync(key, JSON.stringify(prices));
+    }
+
+    const currency = ctx.query.currency;
+    const currencyRate = await getCurrencyRate(currency);
+    for(var asset in prices) {
+      prices[asset] = prices[asset].map(price => price * currencyRate);
     }
 
     ctx.body = { data: prices };

--- a/db/UpdateJob.js
+++ b/db/UpdateJob.js
@@ -1,4 +1,5 @@
 import Exchange from '../exchange/Exchange';
+import { updateCurrencies } from '../exchange/Currencies';
 import { sleep, VALID_PERIODS } from '../utils/period';
 
 const DEFAULT_PERIOD = 60 * 1000;
@@ -14,6 +15,7 @@ class UpdateJob {
     this.interval = setInterval(async () => {
       try {
         await this.exchange.updateAllCache(this.period);
+        await updateCurrencies();
       } catch (e) {
         console.log(`[${this.period}] Update job failed`);
         console.log(e);
@@ -42,4 +44,3 @@ const startCacheUpdateJobs = async () => {
 
 export { startCacheUpdateJobs };
 export default UpdateJob;
-

--- a/exchange/Currencies.js
+++ b/exchange/Currencies.js
@@ -1,0 +1,28 @@
+import redis from '../db/redis';
+import ApiClient from './ApiClient';
+
+const redisKey = `api-currencies`;
+const BASE_URL = 'http://api.fixer.io/latest?base=USD';
+const apiClient = new ApiClient({ baseUrl: BASE_URL });
+
+const getCurrencies = async () => {
+  const response = await apiClient.get('')
+  return response.rates;
+}
+
+export const updateCurrencies = async () => {
+  const currencies = await getCurrencies()
+  await redis.setAsync(redisKey, JSON.stringify(currencies))
+}
+
+export const getCurrencyRate = async (currency = "USD") => {
+  const redisData = await redis.getAsync(redisKey);
+  let currencies = JSON.parse(redisData);
+
+  if (!currencies) {
+    currencies = await getCurrencies()
+    await redis.setAsync(redisKey, JSON.stringify(currencies))
+  }
+
+  return currencies[currency] || 1;
+}


### PR DESCRIPTION
Hey all :wave:, big fan of the Lionshare project! As i'm based in Europe I would love to have the ability to get results in EUR rather than USD. I have made a first pass at adding this functionality to the API by using the http://fixer.io/ API.

I have set the currency rates to be updated inside the UpdateJob class however it may be best reduce the frequency of this call.